### PR TITLE
Switch to Jave 1.8 source level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.target>1.6</maven.compiler.target>
-		<maven.compiler.source>1.6</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>1.8</maven.compiler.source>
 		<nxparser.version>1.2.10</nxparser.version>
 	</properties>
 


### PR DESCRIPTION
Otherwise, the code cannot be built using JDK 17. JDK 8 is the oldest version still receiving free support, so I think this will not be a breaking change, really.